### PR TITLE
Opacity option

### DIFF
--- a/fontobject.lua
+++ b/fontobject.lua
@@ -28,6 +28,7 @@ local default_settings = {
     position_y = 0,
     visible = true,
     text = '',
+    opacity = 1,
 };
 
 local function CreateFontData(settings)
@@ -116,6 +117,10 @@ function object:set_font_color(color)
     end
 
     self.settings.font_color = color;
+end
+
+function object:set_opacity(opacity)
+    self.settings.opacity = math.max(0, math.min(1, opacity));
 end
 
 function object:set_font_family(family)

--- a/include.lua
+++ b/include.lua
@@ -64,7 +64,7 @@ local function render_objects()
     if (sprite ~= nil) then
         sprite:Begin();
         for _,obj in ipairs(objects) do
-            if (obj.settings.visible) then
+            if (obj.settings.visible and obj.settings.opacity > 0) then
                 local texture, rect = obj:get_texture();
                 if (texture ~= nil) then
                     if (obj.settings.font_alignment == 1) then
@@ -75,7 +75,9 @@ local function render_objects()
                         vec_position.x = obj.settings.position_x;
                     end
                     vec_position.y = obj.settings.position_y;
-                    sprite:Draw(texture, rect, vec_scale, nil, 0.0, vec_position, d3dwhite);
+
+                    local render_color = d3d.D3DCOLOR_ARGB(math.ceil(255 * obj.settings.opacity), 255, 255, 255);
+                    sprite:Draw(texture, rect, vec_scale, nil, 0.0, vec_position, render_color);
                 end
             end
         end

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ myFontObject:set_box_height(height); --Sets maximum height of font.  Accepts a n
 myFontObject:set_box_width(width); --Sets maximum width of displayed font.  Accepts a number, 0 will be treated as no maximum.
 myFontObject:set_font_alignment(alignment);  --Sets font alignment.  Accepts gdi.Aligment.Left, gdi.Alignment.Center, or gdi.Alignment.Right.
 myFontObject:set_font_color(color);  --Sets font color.  Accepts a 32 bit ARGB value.
+myFontObject:set_opacity(opacity);  --Sets the overall opacity in the range of 0-1. If you need to simply fade in/out text, this is much better than setting font_color as it avoids texture re-creation.
 myFontObject:set_font_family(family); --Sets font family.  Accepts a string.
 myFontObject:set_font_flags(flags); --Sets font flags.  Accepts gdi.FontFlags.None, gdi.FontFlags.Bold, gdi.FontFlags.Italic, gdi.FontFlags.Underline, gdi.FontFlags.Strikeout, or a combination using bitwise or.
 myFontObject:set_font_height(height); --Sets font height.  Accepts a number.


### PR DESCRIPTION
Added option to set opacity on font object which is much faster than setting the alpha in font_color as it doesn't require texture recreation.