### PR TITLE
Encoding improvements

### DIFF
--- a/encoding.lua
+++ b/encoding.lua
@@ -6,22 +6,61 @@ ffi.cdef[[
 
 local exports = T{};
 
-function exports:ShiftJIS_To_UTF8(input)
-    local buffer = ffi.new('char[4096]');
-    ffi.copy(buffer, input);
-    local wBuffer = ffi.new("wchar_t[4096]");
-    ffi.C.MultiByteToWideChar(932, 0, buffer, -1, wBuffer, 4096);
-    ffi.C.WideCharToMultiByte(65001, 0, wBuffer, -1, buffer, 4096, 0);
-    return ffi.string(buffer);
+local code_page = {
+    utf8 = 65001,
+    shiftjis = 932,
+};
+
+local converted_str_cache = {};
+
+local function Convert_String(input, codepage_from, codepage_to, cache)
+    input = tostring(input or '');
+
+    -- Check cache
+    local cache_key = input .. '|' .. codepage_from .. '>' .. codepage_to;
+    if cache == true then
+        local cached_str = converted_str_cache[cache_key];
+        if cached_str ~= nil then
+            return cached_str;
+        end
+    end
+    
+    -- lua string > char[]
+    local source_length = string.len(input);
+    local cbuffer = ffi.new('char[?]', source_length + 1); -- +1 for zero termination
+    ffi.copy(cbuffer, input);
+
+    -- char[] > wchar_t[]
+    local wchar_length = ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, -1, nil, 0);
+    local wbuffer = ffi.new('wchar_t[?]', wchar_length);
+    ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, -1, wbuffer, wchar_length);
+
+    -- wchar_t[] > char[]
+    local char_length = ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, nil, 0, 0)
+    cbuffer = ffi.new('char[?]', char_length);
+    ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, cbuffer, char_length, 0);
+
+    -- Back to lua string
+    local new_str = ffi.string(cbuffer);
+
+    -- Add to cache
+    if cache == true then
+        converted_str_cache[cache_key] = new_str;
+    end
+
+    return new_str;
 end
 
-function exports:UTF8_To_ShiftJIS(input)
-    local buffer = ffi.new('char[4096]');
-    ffi.copy(buffer, input);
-    local wBuffer = ffi.new("wchar_t[4096]");
-    ffi.C.MultiByteToWideChar(65001, 0, buffer, -1, wBuffer, 4096);
-    ffi.C.WideCharToMultiByte(932, 0, wBuffer, -1, buffer, 4096, 0);
-    return ffi.string(buffer);
+function exports:ShiftJIS_To_UTF8(input, cache)
+    return Convert_String(input, code_page.shiftjis, code_page.utf8, cache);
+end
+
+function exports:UTF8_To_ShiftJIS(input, cache)
+    return Convert_String(input, code_page.utf8, code_page.shiftjis, cache);
+end
+
+function exports:Clear_String_Cache()
+    converted_str_cache = {};
 end
 
 return exports;

--- a/readme.md
+++ b/readme.md
@@ -122,3 +122,8 @@ You can also convert back to shift-JIS if necessary.
 ```
 local sjResourceAgain = encoding:UTF8_To_ShiftJIS(utf8Resource);
 ```
+
+ShiftJIS_To_UTF8 and UTF8_To_ShiftJIS both take an optional second parameter `cache`, which if set to `true` will cache the converted string and skip conversion the next time the same input string is provided.
+```
+local utf8Resource = encoding:ShiftJIS_To_UTF8(sjResource, true);
+```


### PR DESCRIPTION
- Refactored into a single Convert_String function.
- Measure correct length of required buffer when calling MultiByteToWideChar and WideCharToMultiByte.
- Added optional cache param to ShiftJIS_To_UTF8 and UTF8_To_ShiftJIS to have the converted string cached.