### PR TITLE
Fixes an exception which can occur in UTF8_To_ShiftJIS

### DIFF
--- a/encoding.lua
+++ b/encoding.lua
@@ -1,7 +1,7 @@
 local ffi = require('ffi');
 ffi.cdef[[
     int MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, char* lpMultiByteStr, int cbMultiByte, wchar_t* lpMultiByteStr, int32_t cchWideChar);
-    int WideCharToMultiByte(uint32_t CodePage, uint32_t dwFlags, wchar_t* lpWideCharString, int32_t cchWideChar, char* lpMultiByteStr, int32_t cbMultiByte, char lpDefaultChar);
+    int WideCharToMultiByte(uint32_t CodePage, uint32_t dwFlags, wchar_t* lpWideCharStr, int32_t cchWideChar, char* lpMultiByteStr, int32_t cbMultiByte, const char* lpDefaultChar, bool* lpUsedDefaultChar);
 ]]
 
 local exports = T{};
@@ -24,24 +24,24 @@ local function Convert_String(input, codepage_from, codepage_to, cache)
             return cached_str;
         end
     end
-    
+
     -- lua string > char[]
     local source_length = string.len(input);
-    local cbuffer = ffi.new('char[?]', source_length + 1); -- +1 for zero termination
+    local cbuffer = ffi.new('char[?]', source_length);
     ffi.copy(cbuffer, input);
 
     -- char[] > wchar_t[]
-    local wchar_length = ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, -1, nil, 0);
+    local wchar_length = ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, source_length, nil, 0);
     local wbuffer = ffi.new('wchar_t[?]', wchar_length);
-    ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, -1, wbuffer, wchar_length);
+    ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, source_length, wbuffer, wchar_length);
 
     -- wchar_t[] > char[]
-    local char_length = ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, nil, 0, 0)
+    local char_length = ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, wchar_length, nil, 0, nil, nil);
     cbuffer = ffi.new('char[?]', char_length);
-    ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, cbuffer, char_length, 0);
+    ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, wchar_length, cbuffer, char_length, nil, nil);
 
     -- Back to lua string
-    local new_str = ffi.string(cbuffer);
+    local new_str = ffi.string(cbuffer, char_length);
 
     -- Add to cache
     if cache == true then


### PR DESCRIPTION
Fixes an exception which is caused by not supplying correct arguments to WideCharToMultiByte. This only occurs when converting from utf8 back to ShiftJIS and only on certain strings.

I ran the following test in a utf8 lua file:

```
local in_string_utf8 = 'Monster: Goblin Thug, Family: ゴブリン族'
print('in_string_utf8: ' .. #in_string_utf8)
local out_string_sjis = encoding:UTF8_To_ShiftJIS(in_string_utf8)
print('out_string_sjis: ' .. #out_string_sjis)
local out_string_utf8 = encoding:ShiftJIS_To_UTF8(out_string_sjis)
print('out_string_utf8: ' .. #out_string_utf8)
```

Before my changes, I would get a crash when calling the first UTF8_To_ShiftJIS. The line in question was 41, the second call to `WideCharToMultiByte`.

After a bit of digging I discovered the issue was due to the final two params being wrong: 

**lpDefaultChar** -> changed to `const char*`
**lpUsedDefaultChar** -> was missing

This exception only occurs when doing utf8 > shiftjis as these params are not used when converting TO utf8.

While I was there I also removed relying on null termination that I previously added in my last commit, and instead we specify in all methods the char length, since it's faster, especially for the final call to ffi.string.


The above test on my machine now shows the following output:

```
in_string_utf8: 45
out_string_sjis: 40
out_string_utf8: 45
```