### PR TITLE
Change lpDefaultChar to nil on UTF-8 WideCharToMultiByte calls

### DIFF
--- a/encoding.lua
+++ b/encoding.lua
@@ -39,9 +39,9 @@ local function Convert_String(input, codepage_from, codepage_to, cache)
     ffi.C.MultiByteToWideChar(codepage_from, 0, cbuffer, -1, wbuffer, wchar_length);
 
     -- wchar_t[] > char[]
-    local char_length = ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, nil, 0, ' ', nil);
+    local char_length = ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, nil, 0, nil, nil);
     cbuffer = ffi.new('char[?]', char_length);
-    ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, cbuffer, char_length, ' ', nil);
+    ffi.C.WideCharToMultiByte(codepage_to, 0, wbuffer, -1, cbuffer, char_length, nil, nil);
 
     -- Back to lua string
     local new_str = ffi.string(cbuffer);


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte

```For the CP_UTF7 and CP_UTF8 settings for CodePage, this parameter must be set to NULL. Otherwise, the function fails with ERROR_INVALID_PARAMETER.```

Full disclosure, this was found because Linux was displaying junk on some recasts/timers with current-master ttimers, I hunted it down and found this. I guess Linux has different behavior and follows the docs to the letter where Windows doesn't.

I have tested this change on both Linux and Windows and it works fine.

How I figured this out:
WideCharToMultibyte was returning 0 to figure out the size of the string,
GetLastError was reporting ERROR_INVALID_PARAMETER, and the only thing that could've been "invalid" was that.